### PR TITLE
added some changes based on my setup experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,14 +160,10 @@ dist
 
 .vscode-test
 
-# SQLite databases (except production ones)
+# SQLite databases
 *.db
 *.sqlite
 *.sqlite3
-
-# Allow specific production databases
-!data/design-patterns.db
-!data/patterns.db
 .data/
 .data/*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -870,12 +870,16 @@ Update your `.mcp.json`:
   "mcpServers": {
     "design-patterns": {
       "command": "node",
-      "args": ["dist/src/mcp-server-refactored.js"], // Changed
-      "cwd": "/path/to/design-patterns-mcp"
+      "args": ["/absolute/path/to/design-patterns-mcp/dist/src/mcp-server.js"],
+      "env": {
+        "DATABASE_PATH": "/absolute/path/to/design-patterns-mcp/data/design-patterns.db"
+      }
     }
   }
 }
 ```
+
+> **Note:** Use absolute paths. MCP clients like Cursor do not reliably support `cwd`, so relative paths resolve against the user's home directory.
 
 ### Breaking Changes
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -10,15 +10,27 @@
 
 ## Setup (Common)
 
+### Using Bun (recommended)
+
 ```bash
-# Install dependencies
 bun install
-
-# Build project
 bun run build
-
-# Complete database setup
 bun run db:setup
+```
+
+### Using npm
+
+The `prepare` lifecycle script in `package.json` requires `bun`. If you don't have `bun` installed, use `--ignore-scripts` to skip it and build manually with `npx tsc`:
+
+```bash
+npm install --ignore-scripts
+npx tsc
+
+# Setup database
+node dist/src/cli/migrate.js
+node dist/src/cli/seed.js
+node dist/src/cli/generate-embeddings.js
+node dist/src/cli/setup-relationships.js
 ```
 
 ---
@@ -82,7 +94,7 @@ bun run test-mcp-http.js http://localhost:3000/mcp
       "args": ["/absolute/path/to/design-patterns-mcp/dist/src/mcp-server.js"],
       "env": {
         "LOG_LEVEL": "info",
-        "DATABASE_PATH": "./data/design-patterns.db",
+        "DATABASE_PATH": "/absolute/path/to/design-patterns-mcp/data/design-patterns.db",
         "ENABLE_HYBRID_SEARCH": "true",
         "ENABLE_GRAPH_AUGMENTATION": "true"
       }
@@ -90,8 +102,6 @@ bun run test-mcp-http.js http://localhost:3000/mcp
   }
 }
 ```
-
-**Note:** Claude Desktop uses `command` + `args` arrays. Environment variables are inline with the server config.
 
 ---
 
@@ -107,12 +117,11 @@ bun run test-mcp-http.js http://localhost:3000/mcp
 {
   "mcpServers": {
     "design-patterns": {
-      "type": "stdio",
       "command": "node",
       "args": ["/absolute/path/to/design-patterns-mcp/dist/src/mcp-server.js"],
       "env": {
         "LOG_LEVEL": "info",
-        "DATABASE_PATH": "./data/design-patterns.db",
+        "DATABASE_PATH": "/absolute/path/to/design-patterns-mcp/data/design-patterns.db",
         "ENABLE_HYBRID_SEARCH": "true",
         "ENABLE_GRAPH_AUGMENTATION": "true"
       }
@@ -121,12 +130,13 @@ bun run test-mcp-http.js http://localhost:3000/mcp
 }
 ```
 
-**Config interpolation supported:**
+> **Important:** Cursor does not reliably honor the `cwd` field for stdio MCP servers. Always use absolute paths for both `args` and `DATABASE_PATH`. Relative paths will resolve against the user's home directory, causing "Cannot find module" or database errors.
+
+**Project-level config with interpolation:**
 ```json
 {
   "mcpServers": {
     "design-patterns": {
-      "type": "stdio",
       "command": "node",
       "args": ["${workspaceFolder}/dist/src/mcp-server.js"],
       "env": {
@@ -137,6 +147,8 @@ bun run test-mcp-http.js http://localhost:3000/mcp
   }
 }
 ```
+
+> `${workspaceFolder}` interpolation only works in project-level configs (`.cursor/mcp.json`), not in the global `~/.cursor/mcp.json`.
 
 ---
 
@@ -158,7 +170,7 @@ bun run test-mcp-http.js http://localhost:3000/mcp
       "enabled": true,
       "environment": {
         "LOG_LEVEL": "info",
-        "DATABASE_PATH": "./data/design-patterns.db"
+        "DATABASE_PATH": "/absolute/path/to/design-patterns-mcp/data/design-patterns.db"
       }
     }
   }
@@ -191,6 +203,7 @@ Create a shared config file and symlink to both locations:
 mkdir -p ~/.config/shared-mcp
 
 # Save as ~/.config/shared-mcp/design-patterns.json
+# Replace /absolute/path/to/design-patterns-mcp with your actual install path
 cat > ~/.config/shared-mcp/design-patterns.json << 'EOF'
 {
   "mcpServers": {
@@ -199,7 +212,7 @@ cat > ~/.config/shared-mcp/design-patterns.json << 'EOF'
       "args": ["/absolute/path/to/design-patterns-mcp/dist/src/mcp-server.js"],
       "env": {
         "LOG_LEVEL": "info",
-        "DATABASE_PATH": "./data/design-patterns.db",
+        "DATABASE_PATH": "/absolute/path/to/design-patterns-mcp/data/design-patterns.db",
         "ENABLE_HYBRID_SEARCH": "true",
         "ENABLE_GRAPH_AUGMENTATION": "true",
         "EMBEDDING_COMPRESSION": "true",
@@ -218,8 +231,6 @@ ln -sf ~/.config/shared-mcp/design-patterns.json ~/Library/Application\ Support/
 # Link to Cursor
 ln -sf ~/.config/shared-mcp/design-patterns.json ~/.cursor/mcp.json
 ```
-
-**Note:** For Cursor, add `"type": "stdio"` to the server config if you want explicit type declaration.
 
 ---
 
@@ -277,17 +288,53 @@ ln -sf ~/.config/shared-mcp/design-patterns.json ~/.cursor/mcp.json
 
 ## Troubleshooting
 
+### `npm install` fails with "sh: bun: command not found"
+
+The `prepare` lifecycle script requires `bun`. Either install bun (`curl -fsSL https://bun.sh/install | bash`) or skip the hook:
+
+```bash
+npm install --ignore-scripts
+npx tsc
+```
+
+### Cursor shows "Cannot find module" for the MCP server
+
+Cursor does not reliably honor the `cwd` field in MCP server configs. Use absolute paths:
+
+```json
+{
+  "args": ["/absolute/path/to/design-patterns-mcp/dist/src/mcp-server.js"],
+  "env": {
+    "DATABASE_PATH": "/absolute/path/to/design-patterns-mcp/data/design-patterns.db"
+  }
+}
+```
+
+### Cursor shows MCP server errors on startup
+
+The pattern seeder logs warnings about missing cross-references during initialization. Prior to v0.4.4, these used `console.warn()` which writes to stderr — MCP clients like Cursor interpret any stderr output as errors. This was fixed by routing these messages through the structured `logger.warn()`, which writes to stdout and respects the `LOG_LEVEL` setting.
+
+If you see these warnings, rebuild from the latest source:
+
+```bash
+npx tsc    # or: bun run build
+```
+
+Then restart the MCP server in Cursor (`Cmd+Shift+P` → "Developer: Reload Window").
+
+### General reset
+
 ```bash
 # Reset database
 rm data/design-patterns.db
-bun run db:setup
+bun run db:setup    # or use the npm steps above
 
 # Clean build
 rm -rf dist node_modules
-bun install
-bun run build
+bun install         # or: npm install --ignore-scripts
+bun run build       # or: npx tsc
 
-# View Claude Desktop logs
+# View Claude Desktop logs (macOS)
 tail -n 20 -f ~/Library/Logs/Claude/mcp*.log
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,14 +15,17 @@ An intelligent MCP (Model Context Protocol) server that provides design pattern 
 git clone https://github.com/apolosan/design_patterns_mcp.git
 cd design_patterns_mcp
 
-# Install dependencies
+# Install dependencies and build (using bun)
 bun install
-
-# Build and setup database
 bun run db:setup
 
-# Start the server
-bun run dev
+# Or using npm (if bun is not installed)
+npm install --ignore-scripts
+npx tsc
+node dist/src/cli/migrate.js
+node dist/src/cli/seed.js
+node dist/src/cli/generate-embeddings.js
+node dist/src/cli/setup-relationships.js
 ```
 
 Configure in your MCP client (Claude Desktop, Cursor, etc.) and start discovering patterns through natural language queries.
@@ -115,39 +118,42 @@ Ask natural language questions through your MCP client:
 - Node.js >= 18.0.0
 - Bun >= 1.0.0 (recommended) or npm >= 8.0.0
 
-### Setup
+### Setup with Bun
 
 ```bash
-# Install dependencies
 bun install
-
-# Build project
 bun run build
-
-# Complete database setup (migrate + seed + embeddings + relationships)
 bun run db:setup
+```
 
-# Or run steps individually
-bun run migrate
-bun run seed
-bun run generate-embeddings
-bun run setup-relationships
+### Setup with npm
+
+The `prepare` script in `package.json` requires `bun`. If you don't have `bun` installed, use `--ignore-scripts` to skip it and build manually:
+
+```bash
+npm install --ignore-scripts
+npx tsc
+
+# Setup database
+node dist/src/cli/migrate.js
+node dist/src/cli/seed.js
+node dist/src/cli/generate-embeddings.js
+node dist/src/cli/setup-relationships.js
 ```
 
 ### MCP Configuration
 
-Add to your `.mcp.json` or Claude Desktop configuration:
+Add to your MCP client configuration (Claude Desktop, Cursor, etc.):
 
 ```json
 {
   "mcpServers": {
     "design-patterns": {
       "command": "node",
-      "args": ["dist/src/mcp-server.js"],
-      "cwd": "/path/to/design-patterns-mcp",
+      "args": ["/absolute/path/to/design-patterns-mcp/dist/src/mcp-server.js"],
       "env": {
         "LOG_LEVEL": "info",
-        "DATABASE_PATH": "./data/design-patterns.db",
+        "DATABASE_PATH": "/absolute/path/to/design-patterns-mcp/data/design-patterns.db",
         "ENABLE_HYBRID_SEARCH": "true",
         "ENABLE_GRAPH_AUGMENTATION": "true",
         "EMBEDDING_COMPRESSION": "true",
@@ -159,6 +165,8 @@ Add to your `.mcp.json` or Claude Desktop configuration:
   }
 }
 ```
+
+> **Important:** Use absolute paths for both `args` and `DATABASE_PATH`. MCP clients like Cursor do not reliably support the `cwd` field, so relative paths resolve against the user's home directory rather than the project directory. See [QUICKSTART.md](QUICKSTART.md) for client-specific configuration examples.
 
 ## Environment Variables
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "design-patterns-mcp",
@@ -764,8 +765,6 @@
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, ""],
 
     "rc/strip-json-comments": ["strip-json-comments@2.0.1", "", {}, "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="],
-
-    "rimraf/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "win32"
       ],
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.18.0",
+        "@modelcontextprotocol/sdk": "^1.20.0",
         "@xenova/transformers": "^2.17.2",
         "sql.js": "^1.13.0"
       },
@@ -41,8 +41,7 @@
       },
       "engines": {
         "bun": ">=1.0.0",
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": ">=18.0.0"
       },
       "funding": {
         "type": "github",
@@ -198,6 +197,17 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@huggingface/jinja": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.2.2.tgz",
@@ -296,25 +306,63 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.18.0",
-      "license": "MIT",
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.28.0.tgz",
+      "integrity": "sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw==",
       "dependencies": {
-        "ajv": "^6.12.6",
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
         "cors": "^2.8.5",
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.24.1"
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -817,7 +865,8 @@
     },
     "node_modules/accepts": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
       "dependencies": {
         "mime-types": "^3.0.0",
         "negotiator": "^1.0.0"
@@ -858,6 +907,7 @@
     },
     "node_modules/ajv": {
       "version": "6.12.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -869,6 +919,42 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -1048,31 +1134,26 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "license": "MIT",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "dependencies": {
         "bytes": "^3.1.2",
         "content-type": "^1.0.5",
-        "debug": "^4.4.0",
+        "debug": "^4.4.3",
         "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
+        "iconv-lite": "^0.7.0",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/body-parser/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
-      "engines": {
-        "node": ">=0.10.0"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/brace-expansion": {
@@ -1134,7 +1215,8 @@
     },
     "node_modules/bytes": {
       "version": "3.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -1149,7 +1231,8 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -1160,7 +1243,8 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "get-intrinsic": "^1.3.0"
@@ -1262,32 +1346,37 @@
       "license": "MIT"
     },
     "node_modules/content-disposition": {
-      "version": "1.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/content-type": {
       "version": "1.0.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/cookie": {
       "version": "0.7.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
       "engines": {
         "node": ">=6.6.0"
       }
@@ -1322,8 +1411,9 @@
       "peer": true
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "license": "MIT",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -1378,7 +1468,8 @@
     },
     "node_modules/depd": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -1424,7 +1515,8 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -1436,11 +1528,13 @@
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -1456,21 +1550,24 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -1517,7 +1614,8 @@
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -1674,7 +1772,8 @@
     },
     "node_modules/etag": {
       "version": "1.8.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -1739,18 +1838,18 @@
       }
     },
     "node_modules/express": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
-      "license": "MIT",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "dependencies": {
         "accepts": "^2.0.0",
-        "body-parser": "^2.2.0",
+        "body-parser": "^2.2.1",
         "content-disposition": "^1.0.0",
         "content-type": "^1.0.5",
         "cookie": "^0.7.1",
         "cookie-signature": "^1.2.1",
         "debug": "^4.4.0",
+        "depd": "^2.0.0",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
@@ -1781,8 +1880,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.1",
-      "license": "MIT",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -1831,12 +1934,28 @@
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -1869,8 +1988,9 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "2.1.0",
-      "license": "MIT",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "dependencies": {
         "debug": "^4.4.0",
         "encodeurl": "^2.0.0",
@@ -1880,7 +2000,11 @@
         "statuses": "^2.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -1963,14 +2087,16 @@
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/fresh": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -2005,7 +2131,8 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2020,7 +2147,8 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -2042,7 +2170,8 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -2114,7 +2243,8 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -2143,7 +2273,8 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -2153,12 +2284,21 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
+      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/html-escaper": {
@@ -2169,17 +2309,22 @@
       "license": "MIT"
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "license": "MIT",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/human-signals": {
@@ -2191,8 +2336,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "license": "MIT",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -2277,9 +2423,18 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "engines": {
         "node": ">= 0.10"
       }
@@ -2325,7 +2480,8 @@
     },
     "node_modules/is-promise": {
       "version": "4.0.0",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2385,6 +2541,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "dev": true,
@@ -2408,7 +2572,13 @@
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
+      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -2521,21 +2691,24 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
       "engines": {
         "node": ">=18"
       },
@@ -2570,19 +2743,25 @@
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "3.0.1",
-      "license": "MIT",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
       "dependencies": {
         "mime-db": "^1.54.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mimic-fn": {
@@ -2684,7 +2863,8 @@
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -2741,7 +2921,8 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
       "engines": {
         "node": ">= 0.4"
       },
@@ -2751,7 +2932,8 @@
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "dependencies": {
         "ee-first": "1.1.1"
       },
@@ -2906,7 +3088,8 @@
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -2938,7 +3121,8 @@
     },
     "node_modules/path-to-regexp": {
       "version": "8.3.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
@@ -3122,7 +3306,8 @@
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
       "dependencies": {
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
@@ -3143,14 +3328,16 @@
     },
     "node_modules/punycode": {
       "version": "2.3.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "license": "BSD-3-Clause",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
       "dependencies": {
         "side-channel": "^1.1.0"
       },
@@ -3182,19 +3369,21 @@
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.1",
-      "license": "MIT",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.7.0",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.10"
@@ -3239,6 +3428,14 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -3299,7 +3496,8 @@
     },
     "node_modules/router": {
       "version": "2.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
       "dependencies": {
         "debug": "^4.4.0",
         "depd": "^2.0.0",
@@ -3353,7 +3551,8 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
       "version": "7.7.2",
@@ -3366,28 +3565,34 @@
       }
     },
     "node_modules/send": {
-      "version": "1.2.0",
-      "license": "MIT",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
       "dependencies": {
-        "debug": "^4.3.5",
+        "debug": "^4.4.3",
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
         "etag": "^1.8.1",
         "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "mime-types": "^3.0.1",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
         "ms": "^2.1.3",
         "on-finished": "^2.4.1",
         "range-parser": "^1.2.1",
-        "statuses": "^2.0.1"
+        "statuses": "^2.0.2"
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/serve-static": {
-      "version": "2.2.0",
-      "license": "MIT",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
       "dependencies": {
         "encodeurl": "^2.0.0",
         "escape-html": "^1.0.3",
@@ -3396,11 +3601,16 @@
       },
       "engines": {
         "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "node_modules/sharp": {
       "version": "0.32.6",
@@ -3482,7 +3692,8 @@
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3",
@@ -3499,7 +3710,8 @@
     },
     "node_modules/side-channel-list": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
       "dependencies": {
         "es-errors": "^1.3.0",
         "object-inspect": "^1.13.3"
@@ -3513,7 +3725,8 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -3529,7 +3742,8 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
       "dependencies": {
         "call-bound": "^1.0.2",
         "es-errors": "^1.3.0",
@@ -3640,8 +3854,9 @@
       "license": "MIT"
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "license": "MIT",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "engines": {
         "node": ">= 0.8"
       }
@@ -3839,7 +4054,8 @@
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "engines": {
         "node": ">=0.6"
       }
@@ -3899,7 +4115,8 @@
     },
     "node_modules/type-is": {
       "version": "2.0.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
       "dependencies": {
         "content-type": "^1.0.5",
         "media-typer": "^1.1.0",
@@ -3932,13 +4149,15 @@
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "engines": {
         "node": ">= 0.8"
       }
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -4150,17 +4369,19 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "license": "MIT",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.24.6",
-      "license": "ISC",
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
       "peerDependencies": {
-        "zod": "^3.24.1"
+        "zod": "^3.25 || ^4"
       }
     }
   }

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -307,7 +307,6 @@ class DesignPatternsMCPServer {
         capabilities: {
           resources: {},
           tools: {},
-          prompts: {},
         },
       }
     );

--- a/src/services/pattern-seeder.ts
+++ b/src/services/pattern-seeder.ts
@@ -446,7 +446,7 @@ export class PatternSeeder {
         strength = relationship.strength ?? 1.0;
         description = relationship.description ?? `Related to ${targetPatternId}`;
       } else {
-        console.warn(`Invalid relationship format for pattern ${sourcePatternId}:`, relationship);
+        logger.warn('pattern-seeder', `Invalid relationship format for pattern ${sourcePatternId}`, { relationship: String(relationship) });
         return false;
       }
 
@@ -464,9 +464,7 @@ export class PatternSeeder {
           );
 
           if (!targetPattern) {
-            console.warn(
-              `Target pattern not found: ${targetPatternId} (referenced by ${sourcePatternId})`
-            );
+            logger.warn('pattern-seeder', `Target pattern not found: ${targetPatternId} (referenced by ${sourcePatternId})`);
             return false;
           }
           actualTargetId = targetPattern.id;
@@ -478,14 +476,12 @@ export class PatternSeeder {
             [actualTargetId]
           );
           if (!targetPatternExists) {
-            console.warn(
-              `Target pattern ID not found: ${actualTargetId} (referenced by ${sourcePatternId})`
-            );
+            logger.warn('pattern-seeder', `Target pattern ID not found: ${actualTargetId} (referenced by ${sourcePatternId})`);
             return false;
           }
         }
       } else {
-        console.warn(`Invalid targetPatternId for pattern ${sourcePatternId}:`, targetPatternId);
+        logger.warn('pattern-seeder', `Invalid targetPatternId for pattern ${sourcePatternId}`, { targetPatternId: String(targetPatternId) });
         return false;
       }
 


### PR DESCRIPTION
## Great MCP Server
Thanks for your work! After getting set up, I ran some recent tooling changes by your tools and it suggested several relevant improvements. Love it!

## Summary

This PR improves the first-run setup experience based on issues encountered while setting up the project from scratch. The main changes are:

- **Add npm setup instructions alongside bun** — The project currently requires `bun` for the `prepare` lifecycle script. Users without `bun` had no documented path forward. README, QUICKSTART, and CHANGELOG now include `npm install --ignore-scripts && npx tsc` as an alternative, with individual `node dist/src/cli/*.js` commands for database setup.

- **Fix relative path issues with Cursor and other MCP clients** — Cursor does not reliably honor the `cwd` field for stdio MCP servers, causing "Cannot find module" and database errors when using relative paths. All config examples now use absolute paths, with an explicit callout explaining why. The `${workspaceFolder}` interpolation option is documented for project-level configs.

- **Route seeder warnings through structured logger** — `pattern-seeder.ts` used `console.warn()` for missing cross-references during initialization. MCP clients interpret stderr output as errors, which caused noisy false-alarm error banners in Cursor. These are now routed through `logger.warn()` so they respect `LOG_LEVEL` and write to stdout.

- **Remove committed SQLite database from repo** — The 7.5 MB `data/design-patterns.db` binary was tracked in git. Since `db:setup` regenerates it, this removes it and updates `.gitignore` to ignore all `.db` files (removing the `!data/design-patterns.db` exception).

- **Remove unused `prompts` capability** — The MCP server declared an empty `prompts: {}` capability that isn't implemented; removed to avoid confusion.

- **Expand troubleshooting section** — Added specific entries for common failure modes: `bun` not found during `npm install`, Cursor "Cannot find module" errors, and MCP stderr noise from seeder warnings.

## Test plan

- [ ] `bun install && bun run build && bun run db:setup` still works end-to-end
- [ ] `npm install --ignore-scripts && npx tsc` builds successfully without `bun`
- [ ] MCP server starts with absolute paths in Cursor config
- [ ] Seeder warnings no longer appear as errors in Cursor's MCP panel